### PR TITLE
fix: use correct regex

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,7 +4,7 @@ const nextConfig = {
   async redirects() {
     return [
       {
-        source: '/:link(\\w{6})',
+        source: '/:link([A-Za-z0-9_-]{6})',
         destination: `${process.env.NEXT_PUBLIC_API_URL}/:link`,
         permanent: false,
       },


### PR DESCRIPTION
Use same regex as backend to support links with `-`-character